### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/analyze-code.yml
+++ b/.github/workflows/analyze-code.yml
@@ -1,0 +1,31 @@
+# This workflow scans the action code for vulnerabilities when pushing hotfixes
+name: analyze-code
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - 'src/**'
+      - 'package.json'
+jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'release/**'
       - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
@@ -10,8 +11,29 @@ on:
       - 'test/**'
       - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   build:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
     paths:
       - 'action.yml'
       - 'docs/**'

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,4 +1,5 @@
 [![Build status](https://img.shields.io/github/workflow/status/kaskadi/action-npmpub/build?label=build&logo=mocha)](https://github.com/kaskadi/action-npmpub/actions?query=workflow%3Abuild)
+[![Static code analysis status](https://img.shields.io/github/workflow/status/kaskadi/action-npmpub/analyze-code?label=codeQL&logo=github)](https://github.com/kaskadi/action-npmpub/actions?query=workflow%3Aanalyze-code)
 [![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/action-npmpub/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/action-npmpub/actions?query=workflow%3Agenerate-docs)
 
 **CodeClimate**
@@ -6,10 +7,6 @@
 [![](https://img.shields.io/codeclimate/maintainability/kaskadi/action-npmpub?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/action-npmpub)
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/action-npmpub?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/action-npmpub)
 <!-- [![](https://img.shields.io/codeclimate/coverage/kaskadi/action-npmpub?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/action-npmpub) -->
-
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/action-npmpub?label=code%20quality&logo=lgtm)](https://lgtm.com/projects/g/kaskadi/action-npmpub/?mode=list)
 
 ***
 


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` workflow. Also added a separate `analyze-code` workflow for static code analysis when pushing hotfixes.

**Updated features**
- _`build` workflow:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository
- _documentation template:_ updated badges to remove `LGTM` badges, add `analyze-code` badge and add alternative text.